### PR TITLE
Remove import PrettyTable

### DIFF
--- a/categories_pl.py
+++ b/categories_pl.py
@@ -3,7 +3,7 @@ import random
 from sys import platform
 from collections import Counter
 
-from prettytable import PrettyTable
+# from prettytable import PrettyTable
 
 
 possible_letters = [


### PR DESCRIPTION
I removed PrettyTable import because it's not used and causes errors when trying to open the file outside virtualenv.